### PR TITLE
Fix memory leak in the generated code due to improper usage of delete

### DIFF
--- a/compiler/back-ends/c++-gen/cxxmultipleconstraints.c
+++ b/compiler/back-ends/c++-gen/cxxmultipleconstraints.c
@@ -567,7 +567,7 @@ int PrintCxxMultiConstraintOrHandler PARAMS((hdr, src, definedName, e, i),
 			fprintf(src, "%s::operator =(const %s &that)\n", className, className);
 			fprintf(src, "{\n");
 			fprintf(src, "	m_len = that.m_len;\n");
-			fprintf(src, "	delete m_bytes;\n");
+			fprintf(src, "	delete[] m_bytes;\n");
 			fprintf(src, "	m_bytes = new unsigned char[m_len];\n");
 			fprintf(src, "	memcpy(m_bytes, that.m_bytes, m_len);\n");			
 			fprintf(src, "	return *this;\n}\n\n");


### PR DESCRIPTION
Fix memory leak in the generated code due to improper usage of c++ delete on an array allocation. Use delete[] on c++ array allocation.