### PR TITLE
Use the correct accessor for non-pointer object.

### DIFF
--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -4520,7 +4520,10 @@ void PrintCxxSetTypeByCode(NamedType *defByNamedType, CxxTRI *cxxtri, FILE *src)
         NamedType *nt;
         Type      *t = GetType(defByNamedType->type);
 
-        fprintf(src, "  switch (%s.choiceId)\n", defByNamedType->type->cxxTypeRefInfo->fieldName);
+        if (defByNamedType->type->cxxTypeRefInfo->isPtr)
+            fprintf(src, "  switch (%s->choiceId)\n", defByNamedType->type->cxxTypeRefInfo->fieldName);
+        else
+            fprintf(src, "  switch (%s.choiceId)\n", defByNamedType->type->cxxTypeRefInfo->fieldName);
         fprintf(src, "  {\n");
 
         FOR_EACH_LIST_ELMT(nt, t->basicType->a.choice)
@@ -4535,7 +4538,10 @@ void PrintCxxSetTypeByCode(NamedType *defByNamedType, CxxTRI *cxxtri, FILE *src)
               else
                  fprintf (src, ".");
 
-              fprintf(src, "SetTypeByInt(*%s->%s);\n", defByNamedType->type->cxxTypeRefInfo->fieldName, nt->fieldName);
+              if (defByNamedType->type->cxxTypeRefInfo->isPtr)
+                  fprintf(src, "SetTypeByInt(*%s->%s);\n", defByNamedType->type->cxxTypeRefInfo->fieldName, nt->fieldName);
+              else
+                  fprintf(src, "SetTypeByInt(*%s.%s);\n", defByNamedType->type->cxxTypeRefInfo->fieldName, nt->fieldName);
            }
            else
            {
@@ -4545,7 +4551,10 @@ void PrintCxxSetTypeByCode(NamedType *defByNamedType, CxxTRI *cxxtri, FILE *src)
               else
                  fprintf (src, ".");
 
-              fprintf(src, "SetTypeByOid(*%s->%s);\n", defByNamedType->type->cxxTypeRefInfo->fieldName, nt->fieldName);
+              if (defByNamedType->type->cxxTypeRefInfo->isPtr)
+                  fprintf(src, "SetTypeByOid(*%s->%s);\n", defByNamedType->type->cxxTypeRefInfo->fieldName, nt->fieldName);
+              else
+                  fprintf(src, "SetTypeByOid(*%s.%s);\n", defByNamedType->type->cxxTypeRefInfo->fieldName, nt->fieldName);
            }
            fprintf(src, "      break;\n");
 

--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -4520,7 +4520,7 @@ void PrintCxxSetTypeByCode(NamedType *defByNamedType, CxxTRI *cxxtri, FILE *src)
         NamedType *nt;
         Type      *t = GetType(defByNamedType->type);
 
-        fprintf(src, "  switch (%s->choiceId)\n", defByNamedType->type->cxxTypeRefInfo->fieldName);
+        fprintf(src, "  switch (%s.choiceId)\n", defByNamedType->type->cxxTypeRefInfo->fieldName);
         fprintf(src, "  {\n");
 
         FOR_EACH_LIST_ELMT(nt, t->basicType->a.choice)


### PR DESCRIPTION
The c++ code generation logic is broken when using cases. The accessor is incorrect because the instance is not an object pointer.

Use .caseId instead of ->caseId.